### PR TITLE
Gather codecoverage and keep track of changes via coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
-node_js: 0.10
+node_js:
+  - "0.12"
+  - "0.10"
 # installs dependencies for testing
 install: npm install
 # command to run tests
-script: ./node_modules/phantomjs/bin/phantomjs ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html
+script: npm test
+after_success: npm run ci-coverage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoExt 3
 
-[![Build Status](https://travis-ci.org/KaiVolland/geoext3.svg?branch=master)](https://travis-ci.org/KaiVolland/geoext3)
+[![Build Status](https://travis-ci.org/KaiVolland/geoext3.svg?branch=master)](https://travis-ci.org/KaiVolland/geoext3) [![Coverage Status](https://coveralls.io/repos/KaiVolland/geoext3/badge.svg)](https://coveralls.io/r/KaiVolland/geoext3)
 
 This is the first approach for an new geoext structure.
 

--- a/package.json
+++ b/package.json
@@ -1,31 +1,44 @@
 {
-    "name": "GeoExt",
-    "type": "code",
-    "creator": "GeoExt Contributors",
-    "summary": "GIS Package for ExtJS",
-    "detailedDescription": "GeoExt is Open Source and enables building desktop-like GIS applications through the web. It is a JavaScript framework that combines the GIS functionality of OpenLayers with the user interface savvy of the ExtJS library provided by Sencha.",
-    "version": "3.0.0",
-    "compatVersion": "3.0.0",
-    "format": "1",
-    "slicer": {
-        "js": [
-            {
-                "path": "${package.dir}/sass/example/custom.js",
-                "isWidgetManifest": true
-            }
-        ]
-    },
-    "output": "${package.dir}/build",
-    "local": true,
-    "requires": [],
-    "dependencies": {
-    },
-    "devDependencies": {
-        "expect.js": "0.3.1",
-        "jshint": "2.5.6",
-        "mocha": "1.21.5",
-        "mocha-phantomjs": "3.5.1",
-        "phantomjs": "1.9.10",
-        "sinon": "1.10.3"
-    }
+  "name": "GeoExt",
+  "type": "code",
+  "creator": "GeoExt Contributors",
+  "summary": "GIS Package for ExtJS",
+  "detailedDescription": "GeoExt is Open Source and enables building desktop-like GIS applications through the web. It is a JavaScript framework that combines the GIS functionality of OpenLayers with the user interface savvy of the ExtJS library provided by Sencha.",
+  "version": "3.0.0",
+  "compatVersion": "3.0.0",
+  "format": "1",
+  "slicer": {
+    "js": [
+      {
+        "path": "${package.dir}/sass/example/custom.js",
+        "isWidgetManifest": true
+      }
+    ]
+  },
+  "output": "${package.dir}/build",
+  "local": true,
+  "requires": [],
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/KaiVolland/geoext3.git"
+  },
+  "scripts": {
+    "test": "./node_modules/phantomjs/bin/phantomjs ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html",
+    "save-coverage": "./node_modules/phantomjs/bin/phantomjs ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html spec '{\"hooks\": \"../../../test/phantom_hooks.js\"}'",
+    "clean-coverage": "rm -rf src_instrumented src_old coverage",
+    "ci-coverage": "npm run clean-coverage && istanbul instrument src -o src_instrumented && mv src src_old && mv src_instrumented src && istanbul cover npm run save-coverage && mv src src_instrumented && mv src_old src && istanbul report --root ./coverage lcovonly && cat ./coverage/lcov.info | coveralls",
+    "html-coverage": "npm run clean-coverage && istanbul instrument src -o src_instrumented && mv src src_old && mv src_instrumented src && istanbul cover npm run save-coverage && mv src src_instrumented && mv src_old src && istanbul report --root ./coverage html"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "coveralls": "2.11.2",
+    "expect.js": "0.3.1",
+    "istanbul": "0.3.13",
+    "jshint": "2.5.6",
+    "mocha": "1.21.5",
+    "mocha-phantomjs": "3.5.1",
+    "mocha-phantomjs-istanbul": "0.0.2",
+    "phantomjs": "1.9.10",
+    "sinon": "1.10.3"
+  }
 }

--- a/test/phantom_hooks.js
+++ b/test/phantom_hooks.js
@@ -1,0 +1,15 @@
+module.exports = {
+  afterEnd: function(runner) {
+    var fs = require('fs');
+    var coverage = runner.page.evaluate(function() {
+      return window.__coverage__;
+    });
+
+    if (coverage) {
+      console.log('Writing coverage to coverage/coverage.json');
+      fs.write('coverage/coverage.json', JSON.stringify(coverage), 'w');
+    } else {
+      console.log('No coverage data generated');
+    }
+  }
+};


### PR DESCRIPTION
This PR introduces several new callable npm scripts:

* `npm run html-coverage` which will generate a nice HTML coverage report which you can browse locally
* `npm run ci-coverage` which will generate a machine readable coverage report and submit it to coveralls
* `npm test` instead of the existing `./node_modules/phantomjs/bin/phantomjs ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html`

Coveralls needs to enabled for this repository, only the owner @KaiVolland can do this.
