### PR TITLE
Enhance and extend the treepanel examples

### DIFF
--- a/examples/tree/panel.js
+++ b/examples/tree/panel.js
@@ -4,60 +4,92 @@ Ext.require([
     'GeoExt.data.TreeStore'
 ]);
 
-Ext.onReady(function(){
-    var source,
-        layer,
-        map,
-        zoomslider;
+var mapPanel,
+    treePanel;
 
-    source1 = new ol.source.MapQuest({layer: 'sat'});
-    layer1 = new ol.layer.Tile({
-      source: source1
-    });
-
-    source2 = new ol.source.MapQuest({layer: 'osm'});
-    layer2 = new ol.layer.Tile({
-      source: source2
-    });
-
-    source3 = new ol.source.MapQuest({layer: 'hyb'});
-    layer3 = new ol.layer.Tile({
-      source: source3
-    });
-
-    group = new ol.layer.Group({
-        layers: [layer1,layer2]
-    });
-
-    olMap = new ol.Map({
-        layers: [
-                 group,
-                 layer3],
-        view: new ol.View({
-          center: [0, 0],
-          zoom: 2
-        })
-    });
-
-    mapPanel = Ext.create('GeoExt.panel.Map', {
-        title: 'GeoExt.tree.Panel Example',
-        width: 800,
-        height: 600,
-        map: olMap,
-        renderTo: 'mapDiv'
-    });
-
-    treeStore = Ext.create('GeoExt.data.TreeStore', {
-        model: 'GeoExt.data.TreeModel',
-        layerStore: mapPanel.getStore()
-    });
-
-    treePanel = Ext.create('GeoExt.tree.Panel', {
-        title: 'treePanel',
-        width: 400,
-        height: 600,
-        store: treeStore,
-        renderTo: 'treeDiv',
-        rootVisible: false
-    });
+Ext.application({
+    name: 'BasicTree',
+    launch: function(){
+        var source1, source2, source3,
+            layer1, layer2, layer3,
+            group,
+            olMap,
+            treeStore;
+    
+        source1 = new ol.source.MapQuest({layer: 'sat'});
+        layer1 = new ol.layer.Tile({
+            source: source1,
+            name: 'MapQuest Satellite'
+        });
+    
+        source2 = new ol.source.MapQuest({layer: 'osm'});
+        layer2 = new ol.layer.Tile({
+            source: source2,
+            name: 'MapQuest OSM'
+        });
+    
+        source3 = new ol.source.MapQuest({layer: 'hyb'});
+        layer3 = new ol.layer.Tile({
+            source: source3,
+            name: 'MapQuest Hybrid'
+        });
+    
+        group = new ol.layer.Group({
+            layers: [layer1,layer2]
+        });
+    
+        olMap = new ol.Map({
+            layers: [group, layer3],
+            view: new ol.View({
+              center: [0, 0],
+              zoom: 2
+            })
+        });
+    
+        mapPanel = Ext.create('GeoExt.panel.Map', {
+            map: olMap,
+            region: 'center',
+            border: false
+        });
+    
+        treeStore = Ext.create('GeoExt.data.TreeStore', {
+            layerStore: mapPanel.getStore()
+        });
+    
+        treePanel = Ext.create('GeoExt.tree.Panel', {
+            title: 'GeoExt.tree.Panel Example',
+            store: treeStore,
+            rootVisible: false,
+            flex: 1,
+            border: false
+        });
+        
+        var description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            title: 'Description',
+            height: 200,
+            border: false,
+            bodyPadding: 5
+        });
+        
+        Ext.create('Ext.Viewport', {
+            layout: "border",
+            items:[
+                mapPanel,
+                {
+                    xtype: 'panel',
+                    region: 'west',
+                    width: 400,
+                    layout: {
+                        type: 'vbox',
+                        align: 'stretch'
+                    },
+                    items: [
+                        treePanel,
+                        description
+                    ]
+                }
+            ]
+        });
+    }
 });

--- a/examples/tree/tree-legend-simple.html
+++ b/examples/tree/tree-legend-simple.html
@@ -5,6 +5,16 @@
     <title>GeoExt.panel.Map Example</title>
     <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.4.0/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>
+    <style>
+.x-grid-rowbody {
+    padding: 0;
+}
+.legend {
+    margin: 3px 0 0 0;
+    border: 1px solid transparent;
+    border-radius: 6px;
+}
+    </style>
 </head>
 
 <body>
@@ -12,11 +22,13 @@
     <div id='description'>
         <p>
             This example shows how to use the <code>GeoExt.tree.Panel</code>
-            and <code>GeoExt.tree.Store</code> classes.
-        </p>
+            class and shows two methods how to include legends for every
+            treenode.
+        </p> 
         <p>
-            Have a look at <a href="panel.js">panel.js</a> to see how this is
-            done.
+            Have a look at 
+            <a href="tree-legend-simple.js">tree-legend-simple.js</a> to see how
+            this is done.
         </p>
     </div>
 
@@ -30,6 +42,7 @@
                 }
             });
     </script>
-    <script src="panel.js"></script>
+
+    <script src="tree-legend-simple.js"></script>
 </body>
 </html>

--- a/examples/tree/tree-legend-simple.js
+++ b/examples/tree/tree-legend-simple.js
@@ -1,0 +1,227 @@
+Ext.require([
+    'GeoExt.panel.Map',
+    'GeoExt.tree.Panel',
+    'GeoExt.data.TreeStore'
+]);
+
+/**
+ * A plugin for Ext.grid.column.Column s that overwrites the internal cellTpl to
+ * support legends. 
+ */
+Ext.define('BasicTreeColumnLegends', {
+    extend: 'Ext.AbstractPlugin',
+    alias: 'plugin.basic_tree_column_legend',
+
+    /**
+     * @private
+     */
+    originalCellTpl: Ext.clone(Ext.tree.Column.prototype.cellTpl).join(''),
+
+    /**
+     * The Xtemplate strings that will be used instead of the plain {value}
+     * when rendering
+     */
+    valueReplacementTpl: [
+        '{value}',
+        '<tpl if="this.hasLegend(values.record)"><br />',
+            '<tpl for="lines">',
+                '<img src="{parent.blankUrl}" class="{parent.childCls} {parent.elbowCls}-img ',
+                '{parent.elbowCls}-<tpl if=".">line<tpl else>empty</tpl>" role="presentation"/>',
+            '</tpl>',
+            '<img src="{blankUrl}" class="{childCls} x-tree-elbow-img">',
+            '<img src="{blankUrl}" class="{childCls} x-tree-elbow-img">',
+            '<img src="{blankUrl}" class="{childCls} x-tree-elbow-img">',
+            '{[this.getLegendHtml(values.record)]}',
+        '</tpl>'
+    ],
+
+    /**
+     * The context for methods available in the template
+     */
+    valueReplacementContext: {
+        hasLegend: function(rec){
+            var isChecked = rec.get('checked');
+            var layer = rec.data;
+            return isChecked && !(layer instanceof ol.layer.Group);
+        },
+        getLegendHtml: function(rec){
+            var layer = rec.data;
+            var legendUrl = layer.get('legendUrl');
+            if (!legendUrl) {
+                legendUrl = "http://geoext.github.io/geoext2/website-resources/img/GeoExt-logo.png";
+            }
+            return '<img class="legend" src="' + legendUrl + '" height="32" />';
+        }
+    },
+
+    init: function(column){
+        var me = this;
+        if(!(column instanceof Ext.grid.column.Column)) {
+            Ext.log.warn("Plugin shall only be applied to instances of" +
+                    " Ext.grid.column.Column");
+            return;
+        }
+        var valuePlaceHolderRegExp = /\{value\}/g;
+        var replacementTpl = me.valueReplacementTpl.join('');
+        var newCellTpl = me.originalCellTpl.replace(valuePlaceHolderRegExp, replacementTpl);
+
+        column.cellTpl = [
+            newCellTpl,
+            me.valueReplacementContext
+        ];
+    }
+});
+
+var mapPanel,
+    treePanel, treePanel2;
+
+Ext.application({
+    name: 'LegendTrees',
+    launch: function(){
+        var source1, source2, source3,
+            layer1, layer2, layer3, layer4,
+            group,
+            olMap,
+            treeStore, treeStore2;
+
+        source1 = new ol.source.MapQuest({layer: 'sat'});
+        layer1 = new ol.layer.Tile({
+            legendUrl: 'https://otile4-s.mqcdn.com/tiles/1.0.0/sat/4/4/7.jpg',
+            source: source1,
+            name: 'MapQuest Satellite'
+        });
+
+        source2 = new ol.source.MapQuest({layer: 'osm'});
+        layer2 = new ol.layer.Tile({
+            legendUrl: 'https://otile4-s.mqcdn.com/tiles/1.0.0/osm/4/4/7.jpg',
+            source: source2,
+            name: 'MapQuest OSM'
+        });
+
+        source3 = new ol.source.MapQuest({layer: 'hyb'});
+        layer3 = new ol.layer.Tile({
+            legendUrl: 'https://otile4-s.mqcdn.com/tiles/1.0.0/hyb/4/4/7.jpg',
+            source: source3,
+            name: 'MapQuest Hybrid'
+        });
+        
+        layer4 = new ol.layer.Vector({
+            source: new ol.source.Vector(),
+            name: 'Vector '
+        });
+
+        group = new ol.layer.Group({
+            layers: [layer1, layer2]
+        });
+
+        olMap = new ol.Map({
+            layers: [group, layer3, layer4],
+            view: new ol.View({
+                center: [0, 0],
+                zoom: 2
+            })
+        });
+
+        mapPanel = Ext.create('GeoExt.panel.Map', {
+            region: 'center',
+            map: olMap,
+            border: false
+        });
+
+        treeStore = Ext.create('GeoExt.data.TreeStore', {
+            layerStore: mapPanel.getStore()
+        });
+
+        treePanel = Ext.create('GeoExt.tree.Panel', {
+            title: 'Legends in tree panel',
+            store: treeStore,
+            border: false,
+            rootVisible: false,
+            hideHeaders: true,
+            lines: false,
+            flex: 1,
+            columns: {
+                header: false,
+                items: [
+                    {
+                        xtype: 'treecolumn',
+                        dataIndex: 'text',
+                        flex: 1,
+                        plugins: [
+                            {
+                                ptype: 'basic_tree_column_legend'
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        treeStore2 = Ext.create('GeoExt.data.TreeStore', {
+            layerStore: mapPanel.getStore()
+        });
+
+        treePanel2 = Ext.create('GeoExt.tree.Panel', {
+            title: 'treePanel',
+            store: treeStore,
+            rootVisible: false,
+            border: false,
+            flex: 1,
+            hideHeaders: true,
+            lines: false,
+            features: [{
+                ftype: 'rowbody',
+                setupRowData: function(rec, rowIndex, rowValues) {
+                    var headerCt = this.view.headerCt,
+                        colspan = headerCt.getColumnCount(),
+                        isChecked = rec.get('checked'),
+                        layer = rec.data,
+                        hasLegend = isChecked && !(layer instanceof ol.layer.Group),
+                        legendUrl = hasLegend && layer.get('legendUrl');
+                        legHtml = "";
+
+                    if (!legendUrl) {
+                        legendUrl = "http://geoext.github.io/geoext2/website-resources/img/GeoExt-logo.png";
+                    }
+                    legHtml = '<img class="legend" src="' + legendUrl + '" height="32" />';
+
+                    // Usually you would style the my-body-class in CSS file
+                    Ext.apply(rowValues, {
+                        rowBody: hasLegend ? legHtml : "",
+                        rowBodyCls: "my-body-class",
+                        rowBodyColspan: colspan
+                    });
+                }
+            }]
+        });
+
+        var description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            title: 'Description',
+            height: 200,
+            border: false,
+            bodyPadding: 5
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: "border",
+            items:[
+                mapPanel,
+                {
+                    xtype: 'panel',
+                    region: 'west',
+                    width: 400,
+                    layout: {
+                        type: 'vbox',
+                        align: 'stretch'
+                    },
+                    items: [
+                        treePanel,
+                        description,
+                        treePanel2
+                    ]
+                }
+            ]
+        });
+    }
+});


### PR DESCRIPTION
This changes the layout of the basic tree example.

Additionally another example showing two ways of how to add legends to
trees are added.