### PR TITLE
Refactor and enhance the overview component and example

### DIFF
--- a/examples/component/overviewMap.html
+++ b/examples/component/overviewMap.html
@@ -9,8 +9,23 @@
 
 <body>
 
-    <div id='mapDiv' style="float:left;"></div>
-    <div id='panelDiv' style="float:right;"></div>
+    <div id='description'>
+        <p>
+            This example shows how to use the
+            <code>GeoExt.component.OverviewMap</code> class.
+        </p>
+        <p>
+            The overviewmap will visualize the extent of the main map with a
+            rectangle. The main map can be rotated (using <code>SHIFT</code>
+            &amp; drag), and the overviewmap will adjust the rotation of the
+            rectangle. The top-left corner is visualized with a circle in the
+            overviewmap.
+        </p>
+        <p>
+            Have a look at <a href="overviewMap.js">overviewMap.js</a> to see
+            how this is done.
+        </p>
+    </div>
 
     <script src="http://openlayers.org/en/master/build/ol-debug.js"></script>
     <script src="http://cdn.sencha.com/ext/gpl/5.1.0/build/ext-all-debug.js"></script>

--- a/examples/component/overviewMap.js
+++ b/examples/component/overviewMap.js
@@ -3,76 +3,117 @@ Ext.require([
     'GeoExt.component.OverviewMap'
 ]);
 
-Ext.onReady(function(){
-    var source,
-        layer,
-        map,
-        zoomslider;
+var mapPanel,
+    overviewMap1,
+    overviewMap2;
 
-    source = new ol.source.MapQuest({layer: 'sat'});
-    layer = new ol.layer.Tile({
-      source: source
-    });
+Ext.application({
+    name: 'OverviewMaps',
+    launch: function(){
+        var source, source2,
+            layer, layer2,
+            olMap,
+            description,
+            ovMapPanel1, ovMapPanel2;
 
-    source2 = new ol.source.MapQuest({layer: 'osm'});
-    layer2 = new ol.layer.Tile({
-      source: source2
-    });
+        source = new ol.source.MapQuest({layer: 'sat'});
+        layer = new ol.layer.Tile({
+          source: source
+        });
 
-    olMap = new ol.Map({
-        layers: [layer],
-        interactions: ol.interaction.defaults().extend([
-            new ol.interaction.DragRotateAndZoom()
-        ]),
-        view: new ol.View({
-          center: [0, 0],
-          zoom: 2
-        })
-    });
+        source2 = new ol.source.MapQuest({layer: 'osm'});
+        layer2 = new ol.layer.Tile({
+          source: source2
+        });
 
-    mapPanel = Ext.create('GeoExt.panel.Map', {
-        title: 'GeoExt.component.OverviewMap Example',
-        width: 800,
-        height: 600,
-        map: olMap,
-        renderTo: 'mapDiv'
-    });
-
-    overviewMap = Ext.create('GeoExt.component.OverviewMap', {
-        parentMap: olMap,
-        magnification: 10,
-        layers: [layer2],
-        anchorStyle: new ol.style.Style({
-            fill: new ol.style.Fill({
-                color: 'rgba(255, 255, 255, 0.2)'
-              }),
-              stroke: new ol.style.Stroke({
-                color: '#ffcc33',
-                width: 2
-              }),
-              image: new ol.style.Circle({
-                radius: 7,
-                fill: new ol.style.Fill({
-                  color: '#ffcc33'
-                })
-              })
-        }),
-        boxStyle: new ol.style.Style({
-            stroke: new ol.style.Stroke({
-                color: '#ffcc33',
-                width: 2
+        olMap = new ol.Map({
+            layers: [layer],
+            interactions: ol.interaction.defaults().extend([
+                new ol.interaction.DragRotateAndZoom()
+            ]),
+            view: new ol.View({
+              center: [0, 0],
+              zoom: 4
             })
-        })
-    });
+        });
 
-    extPanel = Ext.create('Ext.panel.Panel', {
-        title: 'OverviewMap in Panel',
-        width: 400,
-        height: 200,
-        layout: 'fit',
-        items: [
-            overviewMap
-        ],
-        renderTo: 'panelDiv'
-    });
+        mapPanel = Ext.create('GeoExt.panel.Map', {
+            title: 'GeoExt.component.OverviewMap Example',
+            map: olMap,
+            region: 'center',
+            border: false
+        });
+
+        overviewMap1 = Ext.create('GeoExt.component.OverviewMap', {
+            parentMap: olMap
+        });
+
+        overviewMap2 = Ext.create('GeoExt.component.OverviewMap', {
+            parentMap: olMap,
+            magnification: 12,
+            layers: [layer2],
+            anchorStyle: new ol.style.Style({
+                image: new ol.style.Circle({
+                    radius: 7,
+                    fill: new ol.style.Fill({
+                        color: 'rgb(255, 204, 51)'
+                    })
+                })
+            }),
+            boxStyle: new ol.style.Style({
+                stroke: new ol.style.Stroke({
+                    color: 'rgb(255, 204, 51)',
+                    width: 3
+                }),
+                fill: new ol.style.Fill({
+                    color: 'rgba(255, 204, 51, 0.2)'
+                })
+            })
+        });
+
+        description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            title: 'Description',
+            flex: 1,
+            border: false,
+            bodyPadding: 5,
+            autoScroll: true
+        });
+
+        ovMapPanel1 = Ext.create('Ext.panel.Panel', {
+            title: 'OverviewMap (default)',
+            flex: 1,
+            layout: 'fit',
+            items: overviewMap1
+        });
+
+        ovMapPanel2 = Ext.create('Ext.panel.Panel', {
+            title: 'OverviewMap (configured)',
+            flex: 1,
+            layout: 'fit',
+            items: overviewMap2
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: "border",
+            items:[
+                mapPanel,
+                {
+                    xtype: 'panel',
+                    region: 'east',
+                    width: 400,
+                    border: false,
+                    layout: {
+                        type: 'vbox',
+                        align: 'stretch'
+                    },
+                    items: [
+                        ovMapPanel1,
+                        description,
+                        ovMapPanel2
+                    ]
+                }
+            ]
+        });
+    }
 });

--- a/src/component/OverviewMapController.js
+++ b/src/component/OverviewMapController.js
@@ -2,12 +2,16 @@ Ext.define('GeoExt.component.OverviewMapController', {
     extend: 'Ext.app.ViewController',
     alias: 'controller.component-overviewmap',
 
-    afterRender: function(){
-        var overviewMapComponent = this.getView(),
-            div = overviewMapComponent.getEl().dom,
-            map = overviewMapComponent.getMap();
-
-        map.setTarget(div);
+    onResize: function(){
+        // Get the corresponding view of the controller (the mapPanel).
+        var overview = this.getView(),
+            div = overview.getEl().dom,
+            map = overview.getMap();
+        if(!overview.mapRendered){
+            map.setTarget(div);
+            overview.mapRendered = true;
+        } else {
+            overview.getMap().updateSize();
+        }
     }
-
 });


### PR DESCRIPTION
The overviewmap component had some issues, which this commit tries to fix:

* We were using hardcoded ides of DOM-elements instead of a generic controller
  that handles rendering and updating.
* We were instantiating ol-object when the class was constructed, so that
  multiple instances of the overviewmap would all work on shared instances.
* The above point also meant that we could only have one instance of
  the component since an OpenLayers assertion falure would be raised once you
  instanciate multiple instances.

The controller of the component now is actually being called and mainly does
the same thing that the MapController does, the first time rendering of the
ol.Map and also subsequent updates when the window is resized.

Also included is a commit that enhances the example.