### PR TITLE
Various example enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js: "0.12"
-# installs dependencies for testing
 install: npm install
-# command to run tests
 script:
-  - ./node_modules/eslint/bin/eslint.js src/
+  - npm run lint-js
   - npm test
 after_success: npm run ci-coverage
 branches:

--- a/examples/component/overviewMap.html
+++ b/examples/component/overviewMap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta charset="utf-8">
     <title>GeoExt.component.OverviewMap Example</title>
     <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.4.0/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>

--- a/examples/component/overviewMap.js
+++ b/examples/component/overviewMap.js
@@ -96,7 +96,7 @@ Ext.application({
 
         Ext.create('Ext.Viewport', {
             layout: "border",
-            items:[
+            items: [
                 mapPanel,
                 {
                     xtype: 'panel',

--- a/examples/panel/map.js
+++ b/examples/panel/map.js
@@ -46,7 +46,7 @@ Ext.application({
 
         Ext.create('Ext.Viewport', {
             layout: "border",
-            items:[
+            items: [
                 mapPanel,
                 description
             ]

--- a/examples/tree/panel.html
+++ b/examples/tree/panel.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>GeoExt.panel.Map Example</title>
+    <title>GeoExt.tree.Panel Example</title>
     <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.4.0/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>
 </head>

--- a/examples/tree/panel.html
+++ b/examples/tree/panel.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta charset="utf-8">
     <title>GeoExt.panel.Map Example</title>
     <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.4.0/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>

--- a/examples/tree/panel.js
+++ b/examples/tree/panel.js
@@ -15,29 +15,29 @@ Ext.application({
             group,
             olMap,
             treeStore;
-    
+
         source1 = new ol.source.MapQuest({layer: 'sat'});
         layer1 = new ol.layer.Tile({
             source: source1,
             name: 'MapQuest Satellite'
         });
-    
+
         source2 = new ol.source.MapQuest({layer: 'osm'});
         layer2 = new ol.layer.Tile({
             source: source2,
             name: 'MapQuest OSM'
         });
-    
+
         source3 = new ol.source.MapQuest({layer: 'hyb'});
         layer3 = new ol.layer.Tile({
             source: source3,
             name: 'MapQuest Hybrid'
         });
-    
+
         group = new ol.layer.Group({
-            layers: [layer1,layer2]
+            layers: [layer1, layer2]
         });
-    
+
         olMap = new ol.Map({
             layers: [group, layer3],
             view: new ol.View({
@@ -45,17 +45,17 @@ Ext.application({
               zoom: 2
             })
         });
-    
+
         mapPanel = Ext.create('GeoExt.panel.Map', {
             map: olMap,
             region: 'center',
             border: false
         });
-    
+
         treeStore = Ext.create('GeoExt.data.TreeStore', {
             layerStore: mapPanel.getStore()
         });
-    
+
         treePanel = Ext.create('GeoExt.tree.Panel', {
             title: 'GeoExt.tree.Panel Example',
             store: treeStore,
@@ -63,7 +63,7 @@ Ext.application({
             flex: 1,
             border: false
         });
-        
+
         var description = Ext.create('Ext.panel.Panel', {
             contentEl: 'description',
             title: 'Description',
@@ -71,10 +71,10 @@ Ext.application({
             border: false,
             bodyPadding: 5
         });
-        
+
         Ext.create('Ext.Viewport', {
             layout: "border",
-            items:[
+            items: [
                 mapPanel,
                 {
                     xtype: 'panel',

--- a/examples/tree/tree-legend-simple.html
+++ b/examples/tree/tree-legend-simple.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta charset="utf-8">
     <title>GeoExt.panel.Map Example</title>
     <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.4.0/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>

--- a/examples/tree/tree-legend-simple.html
+++ b/examples/tree/tree-legend-simple.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>GeoExt.panel.Map Example</title>
+    <title>GeoExt.tree.Panel plus legends Example</title>
     <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.4.0/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>
     <style>

--- a/examples/tree/tree-legend-simple.js
+++ b/examples/tree/tree-legend-simple.js
@@ -6,7 +6,7 @@ Ext.require([
 
 /**
  * A plugin for Ext.grid.column.Column s that overwrites the internal cellTpl to
- * support legends. 
+ * support legends.
  */
 Ext.define('BasicTreeColumnLegends', {
     extend: 'Ext.AbstractPlugin',
@@ -104,7 +104,7 @@ Ext.application({
             source: source3,
             name: 'MapQuest Hybrid'
         });
-        
+
         layer4 = new ol.layer.Vector({
             source: new ol.source.Vector(),
             name: 'Vector '
@@ -163,7 +163,7 @@ Ext.application({
 
         treePanel2 = Ext.create('GeoExt.tree.Panel', {
             title: 'treePanel',
-            store: treeStore,
+            store: treeStore2,
             rootVisible: false,
             border: false,
             flex: 1,
@@ -177,7 +177,7 @@ Ext.application({
                         isChecked = rec.get('checked'),
                         layer = rec.data,
                         hasLegend = isChecked && !(layer instanceof ol.layer.Group),
-                        legendUrl = hasLegend && layer.get('legendUrl');
+                        legendUrl = hasLegend && layer.get('legendUrl'),
                         legHtml = "";
 
                     if (!legendUrl) {
@@ -205,7 +205,7 @@ Ext.application({
 
         Ext.create('Ext.Viewport', {
             layout: "border",
-            items:[
+            items: [
                 mapPanel,
                 {
                     xtype: 'panel',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "scripts": {
     "test": "./node_modules/phantomjs/bin/phantomjs --ssl-protocol=any --ignore-ssl-errors=true ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html",
+    "lint-js": "./node_modules/eslint/bin/eslint.js src/ examples/",
     "save-coverage": "./node_modules/phantomjs/bin/phantomjs --ssl-protocol=any --ignore-ssl-errors=true ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html spec '{\"hooks\": \"../../../test/phantom_hooks.js\"}'",
     "clean-coverage": "rm -rf src_instrumented src_old coverage",
     "ci-coverage": "npm run clean-coverage && istanbul instrument src -o src_instrumented && mv src src_old && mv src_instrumented src && istanbul cover npm run save-coverage && mv src src_instrumented && mv src_old src && istanbul report --root ./coverage lcovonly && cat ./coverage/lcov.info | coveralls",


### PR DESCRIPTION
* Use `<meta charset=utf-8>` in examples
* Fix the titles of examples
* Fix lint errors in example JavaScript
* Lint example JavaScript on travis